### PR TITLE
Specify bus in EventBusSubscriber annotation

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -7,7 +7,7 @@ yarn = "1.21.1+build.3"
 kaleido = "0.3.3+1.3.2"
 yacl = "3.7.0+1.21.1-neoforge"
 
-neo = "21.1.183"
+neo = "21.1.185"
 neoYarn = "1.21+build.4"
 
 [plugins]

--- a/src/main/java/dev/sisby/mcqoy/McQoy.java
+++ b/src/main/java/dev/sisby/mcqoy/McQoy.java
@@ -58,7 +58,7 @@ import java.util.Objects;
 import java.util.function.Function;
 
 @Mod(McQoy.ID)
-@EventBusSubscriber(modid = McQoy.ID)
+@EventBusSubscriber(modid = McQoy.ID, bus = EventBusSubscriber.Bus.MOD)
 public class McQoy {
 	public static final String ID = "mcqoy";
 	public static final Logger LOGGER = LoggerFactory.getLogger(ID);


### PR DESCRIPTION
Fixes compatibility with NeoForge 21.1.180 and below.

The value is deprecated and marked for removal, but I believe this is referring to the removal of the value in NeoForge 21.6, which hopefully will never affect 1.21.5 and below.