### PR TITLE
Port to 26.1-snapshot-5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: JDK Setup
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 25
           distribution: 'temurin'
 
       - name: Gradle Setup

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,10 @@ plugins {
 }
 
 version = "$modVersion+$branchName"
-archivesBaseName = project.slug
+
+base {
+	archivesName = project.slug
+}
 
 repositories {
 	maven { url "https://repo.sleeping.town/" }
@@ -19,14 +22,13 @@ repositories {
 
 dependencies {
 	minecraft libs.mc
-	mappings variantOf(libs.yarn) { classifier "v2" }
 
-	modImplementation libs.fl
+	implementation libs.fl
 	implementation libs.kaleido
-	modImplementation libs.yacl
-	modImplementation libs.modmenu
+	implementation libs.yacl
+	implementation libs.modmenu
 
-	modRuntimeOnly libs.fapi
+	implementation libs.fapi
 
 	include libs.kaleido
 }
@@ -56,18 +58,18 @@ processResources {
 
 tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
-	it.options.release = 17
+	it.options.release = 25
 }
 
 java {
 	withSourcesJar()
 	sourceCompatibility = JavaVersion.VERSION_1_8
-	targetCompatibility = JavaVersion.VERSION_17
+	targetCompatibility = JavaVersion.VERSION_25
 }
 
 jar {
 	from("LICENSE") {
-		rename { "${it}_${archivesBaseName}" }
+		rename { "${it}_${base.archivesName}" }
 	}
 }
 
@@ -87,7 +89,7 @@ githubRelease {
 	repo = slug
 	tagName = "v${modVersion}"
 	targetCommitish = branchName
-	releaseAssets = remapJar
+	releaseAssets = jar
 	allowUploadToExisting = true
 	generateReleaseNotes = true
 	body = !file("CHANGELOG.md").exists() ? "" : rootProject.file("CHANGELOG.md").text
@@ -97,7 +99,7 @@ modrinth {
 	token = "$System.env.MODRINTH_TOKEN"
 	projectId = slug
 	versionNumber = project.version
-	uploadFile = remapJar
+	uploadFile = jar
 	gameVersions = compatibleVersions.split(", ").toList()
 	loaders = compatibleLoaders.split(", ").toList()
 	changelog = !file("CHANGELOG.md").exists() ? "" : rootProject.file("CHANGELOG.md").text + "\n\nChangelog: https://github.com/${user}/${slug}/releases/tag/v${modVersion}"
@@ -112,7 +114,7 @@ tasks.register('curseforge', net.darkhax.curseforgegradle.TaskPublishCurseForge)
 	apiToken = "$System.env.CURSEFORGE_TOKEN"
 	disableVersionDetection()
 	def projectId = "1402884"
-	def mainFile = upload(projectId, remapJar)
+	def mainFile = upload(projectId, jar)
 	compatibleLoaders.split(", ").toList().forEach { mainFile.addModLoader(it) }
 	compatibleVersions.split(", ").toList().forEach { mainFile.addGameVersion(it) }
 	mainFile.addEnvironment("client")

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,6 @@ license=MIT
 # Mod Version
 modVersion=0.4.1
 # Branch Metadata
-branchName=fabric-1.20
-compatibleVersions=1.20.1, 1.20.2, 1.20.3, 1.20.4, 1.20.5, 1.20.6, 1.21, 1.21.1, 1.21.2, 1.21.3, 1.21.4, 1.21.5, 1.21.6, 1.21.7, 1.21.8, 1.21.9, 1.21.10, 1.21.11
+branchName=fabric-26.1
+compatibleVersions=26.1-alpha.2
 compatibleLoaders=fabric

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,19 +1,18 @@
 [versions]
-loom = "1.10.+"
+loom = "1.15.+"
 githubRelease = "2.4.1"
 minotaur = "2.+"
 curse = "1.1.+"
 
-mc = "1.20.1"
-fl = "0.16.10"
-yarn = "1.20.1+build.10"
-fapi = "0.92.2+1.20.1"
+mc = "26.1-snapshot-5"
+fl = "0.18.4"
+fapi = "0.143.0+26.1"
 kaleido = "0.3.3+1.3.2"
-yacl = "3.6.6+1.20.1-fabric"
-modmenu = "7.2.2"
+yacl = "3.8.2+26.1.0-fabric"
+modmenu = "18.0.0-alpha.5"
 
 [plugins]
-loom = { id = "fabric-loom", version.ref = "loom" }
+loom = { id = "net.fabricmc.fabric-loom", version.ref = "loom" }
 githubRelease = { id = "com.github.breadmoirai.github-release", version.ref = "githubRelease" }
 minotaur = { id = "com.modrinth.minotaur", version.ref = "minotaur" }
 curse = { id = "net.darkhax.curseforgegradle", version.ref = "curse" }
@@ -21,7 +20,6 @@ curse = { id = "net.darkhax.curseforgegradle", version.ref = "curse" }
 [libraries]
 mc = { group = "mojang", name = "minecraft", version.ref = "mc" }
 fl = { group = "net.fabricmc", name = "fabric-loader", version.ref = "fl" }
-yarn = { group = "net.fabricmc", name = "yarn", version.ref = "yarn" }
 fapi = { group = "net.fabricmc.fabric-api", name = "fabric-api", version.ref = "fapi" }
 kaleido = { group = "folk.sisby", name = "kaleido-config", version.ref = "kaleido" }
 yacl = { group = "dev.isxander", name = "yet-another-config-lib", version.ref = "yacl" }

--- a/src/main/java/dev/sisby/mcqoy/McQoy.java
+++ b/src/main/java/dev/sisby/mcqoy/McQoy.java
@@ -39,9 +39,9 @@ import folk.sisby.kaleido.lib.quiltconfig.impl.values.ValueListImpl;
 import folk.sisby.kaleido.lib.quiltconfig.impl.values.ValueMapImpl;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
 import net.minecraft.util.Util;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -121,21 +121,21 @@ public class McQoy implements ModInitializer {
 
 	public static Screen createScreen(Screen parent, String modId, Collection<Config> configs) {
 		String modName = FabricLoader.getInstance().getModContainer(modId).get().getMetadata().getName();
-		final YetAnotherConfigLib.Builder builder = YetAnotherConfigLib.createBuilder().title(Text.of("Config: " + modName));
+		final YetAnotherConfigLib.Builder builder = YetAnotherConfigLib.createBuilder().title(Component.nullToEmpty("Config: " + modName));
 		LinkedHashMap<String, ConfigCategory.Builder> categories = new LinkedHashMap<>();
 		for (Config config : configs) {
 			String simpleName = config.family().isEmpty() ? config.id() : config.family();
-			Text configDisplayName = configs.size() == 1 ? Text.of(modName) : getDisplayName(config, simpleName, NamingSchemes.TITLE_CASE);
+			Component configDisplayName = configs.size() == 1 ? Component.nullToEmpty(modName) : getDisplayName(config, simpleName, NamingSchemes.TITLE_CASE);
 			ConfigCategory.Builder category;
 			for (TrackedValue<?> field : config.values()) {
 				if (field.key().length() == 1) { // No Section
 					category = categories.computeIfAbsent(configDisplayName.getString(), k -> ConfigCategory.createBuilder().name(configDisplayName));
 				} else { // With section, take topmost
 					ValueTreeNode topSection = config.getNode(Collections.singletonList(field.key().getKeyComponent(0)));
-					Text sectionDisplayName = getDisplayName(topSection, topSection.key().getLastComponent(), NamingSchemes.TITLE_CASE);
+					Component sectionDisplayName = getDisplayName(topSection, topSection.key().getLastComponent(), NamingSchemes.TITLE_CASE);
 					category = categories.computeIfAbsent(sectionDisplayName.getString(), k -> ConfigCategory.createBuilder().name(sectionDisplayName));
 				}
-				mapAndAddField(config, field, category, getDisplayName(field, field.key().getLastComponent(), NamingSchemes.SPACE_SEPARATED_LOWER_CASE_INITIAL_UPPER_CASE), getComments(field).stream().map(Text::of).toArray(Text[]::new));
+				mapAndAddField(config, field, category, getDisplayName(field, field.key().getLastComponent(), NamingSchemes.SPACE_SEPARATED_LOWER_CASE_INITIAL_UPPER_CASE), getComments(field).stream().map(Component::nullToEmpty).toArray(Component[]::new));
 			}
 		}
 		for (ConfigCategory.Builder s : categories.values()) {
@@ -147,7 +147,7 @@ public class McQoy implements ModInitializer {
 	}
 
 	@SuppressWarnings({"unchecked", "rawtypes"})
-	private static void mapAndAddField(Config config, TrackedValue<?> field, ConfigCategory.Builder category, Text displayName, Text[] description) {
+	private static void mapAndAddField(Config config, TrackedValue<?> field, ConfigCategory.Builder category, Component displayName, Component[] description) {
 		Constraint.Range<?> tempRangeConstraint = null;
 		boolean color = false;
 		boolean tempAlpha = false;
@@ -204,15 +204,15 @@ public class McQoy implements ModInitializer {
 		}
 	}
 
-	private static void incompatibleOption(Config config, ConfigCategory.Builder category, Text displayName, Text[] description) {
-		Text[] desc = Stream.concat(
+	private static void incompatibleOption(Config config, ConfigCategory.Builder category, Component displayName, Component[] description) {
+		Component[] desc = Stream.concat(
 			Arrays.stream(description),
 			Stream.of(
-				Text.of(""),
-				Text.of(String.format("Only editable via %s", (config.family().isEmpty() ? "" : (config.family() + "/")) + config.id() + ".toml")).copy().formatted(Formatting.YELLOW),
-				Text.of("Exit the game first.").copy().formatted(Formatting.RED)
-			)).toArray(Text[]::new);
-		category.option(ButtonOption.createBuilder().name(displayName).text(Text.of("Edit in file...")).description(OptionDescription.of(desc)).action((s, o) -> Util.getOperatingSystem().open(FabricLoader.getInstance().getConfigDir().toFile())).build());
+				Component.nullToEmpty(""),
+				Component.nullToEmpty(String.format("Only editable via %s", (config.family().isEmpty() ? "" : (config.family() + "/")) + config.id() + ".toml")).copy().withStyle(ChatFormatting.YELLOW),
+				Component.nullToEmpty("Exit the game first.").copy().withStyle(ChatFormatting.RED)
+			)).toArray(Component[]::new);
+		category.option(ButtonOption.createBuilder().name(displayName).text(Component.nullToEmpty("Edit in file...")).description(OptionDescription.of(desc)).action((s, o) -> Util.getPlatform().openFile(FabricLoader.getInstance().getConfigDir().toFile())).build());
 	}
 
 	private static Color colorOrWhite(String string, boolean alpha) {
@@ -227,13 +227,13 @@ public class McQoy implements ModInitializer {
 		return "#" + StringUtils.leftPad(Integer.toHexString(color.getRGB() & (alpha ? 0xFF_FFFFFF : 0x00_FFFFFF)), alpha ? 8 : 6, "0");
 	}
 
-	private static <T, C> void singleOption(TrackedValue<T> field, ConfigCategory.Builder category, Text displayName, Text[] description, Function<Option<C>, ControllerBuilder<C>> controller, Function<T, C> getBinder, Function<C, T> setBinder) {
+	private static <T, C> void singleOption(TrackedValue<T> field, ConfigCategory.Builder category, Component displayName, Component[] description, Function<Option<C>, ControllerBuilder<C>> controller, Function<T, C> getBinder, Function<C, T> setBinder) {
 		category.option(Option.<C>createBuilder().name(displayName).description(OptionDescription.of(description)).binding(getBinder.apply(field.getDefaultValue()), () -> getBinder.apply(field.value()), v -> {
 			if (field.checkForFailingConstraints(setBinder.apply(v)).isEmpty()) field.setValue(setBinder.apply(v));
 		}).controller(controller).build());
 	}
 
-	private static <T, C> void listOption(TrackedValue<ValueList<T>> field, ConfigCategory.Builder category, Text displayName, Text[] description, Function<Option<C>, ControllerBuilder<C>> controller, Function<T, C> getBinder, Function<C, T> setBinder) {
+	private static <T, C> void listOption(TrackedValue<ValueList<T>> field, ConfigCategory.Builder category, Component displayName, Component[] description, Function<Option<C>, ControllerBuilder<C>> controller, Function<T, C> getBinder, Function<C, T> setBinder) {
 		category.group(ListOption.<C>createBuilder().name(displayName).description(OptionDescription.of(description)).binding(field.getDefaultValue().stream().map(getBinder).collect(Collectors.toList()), () -> field.value().stream().map(getBinder).collect(Collectors.toList()),
 			l -> {
 				if (field.checkForFailingConstraints(new ValueListImpl<T>(field.value().getDefaultValue(), l.stream().map(setBinder).collect(Collectors.toList()))).isPresent()) return;
@@ -243,7 +243,7 @@ public class McQoy implements ModInitializer {
 		).controller(controller).initial(getBinder.apply(field.getDefaultValue().getDefaultValue())).build());
 	}
 
-	private static <T, C> void mapOption(TrackedValue<ValueMap<T>> field, ConfigCategory.Builder category, Text displayName, Text[] description, Function<Option<C>, ControllerBuilder<C>> valueController, Function<T, C> getBinder, Function<C, T> setBinder) {
+	private static <T, C> void mapOption(TrackedValue<ValueMap<T>> field, ConfigCategory.Builder category, Component displayName, Component[] description, Function<Option<C>, ControllerBuilder<C>> valueController, Function<T, C> getBinder, Function<C, T> setBinder) {
 		category.group(ListOption.<Map.Entry<String, C>>createBuilder().name(displayName).description(OptionDescription.of(description)).binding(
 			field.getDefaultValue().entrySet().stream().map(e -> Map.entry(e.getKey(), getBinder.apply(e.getValue()))).collect(Collectors.toList()),
 			() -> field.value().entrySet().stream().map(e -> Map.entry(e.getKey(), getBinder.apply(e.getValue()))).collect(Collectors.toList()),
@@ -256,14 +256,14 @@ public class McQoy implements ModInitializer {
 	}
 
 	@SuppressWarnings("unchecked")
-	private static <T extends Enum<T>> void enumOption(TrackedValue<?> field, ConfigCategory.Builder category, Text displayName, Text[] description, T defaultValue) {
+	private static <T extends Enum<T>> void enumOption(TrackedValue<?> field, ConfigCategory.Builder category, Component displayName, Component[] description, T defaultValue) {
 		category.option(Option.<T>createBuilder().name(displayName).description(OptionDescription.of(description)).binding(defaultValue, () -> (T) field.value(), v -> ((TrackedValue<T>) field).setValue(v)).controller(
 			o -> EnumControllerBuilder.create(o).enumClass(defaultValue.getDeclaringClass())
 		).build());
 	}
 
 	@SuppressWarnings("unchecked")
-	private static <T extends Enum<T>> void enumListOption(TrackedValue<?> field, ConfigCategory.Builder category, Text displayName, Text[] description, ValueList<?> defaultList, T defaultValue) {
+	private static <T extends Enum<T>> void enumListOption(TrackedValue<?> field, ConfigCategory.Builder category, Component displayName, Component[] description, ValueList<?> defaultList, T defaultValue) {
 		category.group(ListOption.<T>createBuilder().name(displayName).description(OptionDescription.of(description)).binding((List<T>) defaultList, () -> (ValueList<T>) field.value(),
 			l -> {
 				((TrackedValue<ValueList<T>>) field).value().clear();
@@ -273,7 +273,7 @@ public class McQoy implements ModInitializer {
 	}
 
 	@SuppressWarnings("unchecked")
-	private static <T extends Enum<T>> void enumMapOption(TrackedValue<?> field, ConfigCategory.Builder category, Text displayName, Text[] description, T defaultValue) {
+	private static <T extends Enum<T>> void enumMapOption(TrackedValue<?> field, ConfigCategory.Builder category, Component displayName, Component[] description, T defaultValue) {
 		category.group(ListOption.<Map.Entry<String, T>>createBuilder().name(displayName).description(OptionDescription.of(description)).binding(
 			((TrackedValue<ValueMap<T>>) field).getDefaultValue().entrySet().stream().collect(Collectors.toList()),
 			() -> ((TrackedValue<ValueMap<T>>) field).value().entrySet().stream().collect(Collectors.toList()),
@@ -303,7 +303,7 @@ public class McQoy implements ModInitializer {
 		return opt -> FloatSliderControllerBuilder.create(opt)
 			.range((Float) rangeConstraint.min(), (Float) rangeConstraint.max())
 			.step(0.01F)
-			.formatValue(f -> Text.of(String.format("%.2f", f)));
+			.formatValue(f -> Component.nullToEmpty(String.format("%.2f", f)));
 	}
 
 	private static Function<Option<Double>, ControllerBuilder<Double>> doubleOrSliderController(Constraint.Range<?> rangeConstraint) {
@@ -311,14 +311,14 @@ public class McQoy implements ModInitializer {
 		return opt -> DoubleSliderControllerBuilder.create(opt)
 			.range((Double) rangeConstraint.min(), (Double) rangeConstraint.max())
 			.step(0.01)
-			.formatValue(f -> Text.of(String.format("%.2f", f)));
+			.formatValue(f -> Component.nullToEmpty(String.format("%.2f", f)));
 	}
 
-	public static Text getDisplayName(MetadataContainer value, String fallback, NamingScheme fallbackScheme) {
+	public static Component getDisplayName(MetadataContainer value, String fallback, NamingScheme fallbackScheme) {
 		if (value.hasMetadata(DisplayName.TYPE)) {
-			return Text.of(value.metadata(DisplayName.TYPE).getName());
+			return Component.nullToEmpty(value.metadata(DisplayName.TYPE).getName());
 		} else {
-			return Text.of((value.hasMetadata(DisplayNameConvention.TYPE) ? value.metadata(DisplayNameConvention.TYPE) : fallbackScheme).coerce(fallback));
+			return Component.nullToEmpty((value.hasMetadata(DisplayNameConvention.TYPE) ? value.metadata(DisplayNameConvention.TYPE) : fallbackScheme).coerce(fallback));
 		}
 	}
 

--- a/src/main/java/dev/sisby/mcqoy/yacl/EntryController.java
+++ b/src/main/java/dev/sisby/mcqoy/yacl/EntryController.java
@@ -6,11 +6,11 @@ import dev.isxander.yacl3.api.controller.ControllerBuilder;
 import dev.isxander.yacl3.api.utils.Dimension;
 import dev.isxander.yacl3.gui.AbstractWidget;
 import dev.isxander.yacl3.gui.YACLScreen;
-import net.minecraft.text.Text;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 import java.util.function.Function;
+import net.minecraft.network.chat.Component;
 
 public class EntryController<T> implements Controller<Map.Entry<String, T>> {
 	private final Option<Map.Entry<String, T>> option;
@@ -29,8 +29,8 @@ public class EntryController<T> implements Controller<Map.Entry<String, T>> {
 	}
 
 	@Override
-	public Text formatValue() {
-		return Text.literal(option.pendingValue().toString());
+	public Component formatValue() {
+		return Component.literal(option.pendingValue().toString());
 	}
 
 	@Override

--- a/src/main/java/dev/sisby/mcqoy/yacl/EntryControllerElement.java
+++ b/src/main/java/dev/sisby/mcqoy/yacl/EntryControllerElement.java
@@ -5,7 +5,9 @@ import dev.isxander.yacl3.gui.AbstractWidget;
 import dev.isxander.yacl3.gui.YACLScreen;
 import dev.isxander.yacl3.gui.controllers.ControllerWidget;
 import dev.isxander.yacl3.gui.controllers.TickBoxController;
-import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.client.input.MouseButtonEvent;
 
 public class EntryControllerElement<T> extends ControllerWidget<EntryController<T>> {
 	private final AbstractWidget keyWidget;
@@ -18,17 +20,17 @@ public class EntryControllerElement<T> extends ControllerWidget<EntryController<
 	}
 
 	@Override
-	public boolean mouseClicked(double mouseX, double mouseY, int button) {
-		return keyWidget.mouseClicked(mouseX, mouseY, button) || valueWidget.mouseClicked(mouseX, mouseY, button);
+	public boolean mouseClicked(MouseButtonEvent mouseButtonEvent, boolean doubleClick) {
+		return keyWidget.mouseClicked(mouseButtonEvent, doubleClick) || valueWidget.mouseClicked(mouseButtonEvent, doubleClick);
 	}
 
 	@Override
-	public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-		return keyWidget.keyPressed(keyCode, scanCode, modifiers) || valueWidget.keyPressed(keyCode, scanCode, modifiers);
+	public boolean keyPressed(KeyEvent keyEvent) {
+		return keyWidget.keyPressed(keyEvent) || valueWidget.keyPressed(keyEvent);
 	}
 
 	@Override
-	public void render(DrawContext graphics, int mouseX, int mouseY, float delta) {
+	public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
 		keyWidget.render(graphics, mouseX, mouseY, delta);
 		valueWidget.render(graphics, mouseX, mouseY, delta);
 	}

--- a/src/main/java/dev/sisby/mcqoy/yacl/MapKeyOption.java
+++ b/src/main/java/dev/sisby/mcqoy/yacl/MapKeyOption.java
@@ -10,7 +10,6 @@ import dev.isxander.yacl3.api.OptionFlag;
 import dev.isxander.yacl3.api.StateManager;
 import dev.isxander.yacl3.api.controller.ControllerBuilder;
 import dev.isxander.yacl3.impl.ProvidesBindingForDeprecation;
-import net.minecraft.text.Text;
 import org.apache.commons.lang3.Validate;
 import org.jetbrains.annotations.NotNull;
 
@@ -18,6 +17,7 @@ import java.util.AbstractMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import net.minecraft.network.chat.Component;
 
 public class MapKeyOption<T> implements Option<String> {
 	private final Option<Map.Entry<String, T>> mapOption;
@@ -37,8 +37,8 @@ public class MapKeyOption<T> implements Option<String> {
 	}
 
 	@Override
-	public @NotNull Text name() {
-		return Text.empty();
+	public @NotNull Component name() {
+		return Component.empty();
 	}
 
 	@Override
@@ -47,7 +47,7 @@ public class MapKeyOption<T> implements Option<String> {
 	}
 
 	@Override
-	public @NotNull Text tooltip() {
+	public @NotNull Component tooltip() {
 		return mapOption.tooltip();
 	}
 

--- a/src/main/java/dev/sisby/mcqoy/yacl/MapValueOption.java
+++ b/src/main/java/dev/sisby/mcqoy/yacl/MapValueOption.java
@@ -10,7 +10,6 @@ import dev.isxander.yacl3.api.OptionFlag;
 import dev.isxander.yacl3.api.StateManager;
 import dev.isxander.yacl3.api.controller.ControllerBuilder;
 import dev.isxander.yacl3.impl.ProvidesBindingForDeprecation;
-import net.minecraft.text.Text;
 import org.apache.commons.lang3.Validate;
 import org.jetbrains.annotations.NotNull;
 
@@ -18,6 +17,7 @@ import java.util.AbstractMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import net.minecraft.network.chat.Component;
 
 public class MapValueOption<T> implements Option<T> {
 	private final Option<Map.Entry<String, T>> mapOption;
@@ -37,8 +37,8 @@ public class MapValueOption<T> implements Option<T> {
 	}
 
 	@Override
-	public @NotNull Text name() {
-		return Text.empty();
+	public @NotNull Component name() {
+		return Component.empty();
 	}
 
 	@Override
@@ -47,7 +47,7 @@ public class MapValueOption<T> implements Option<T> {
 	}
 
 	@Override
-	public @NotNull Text tooltip() {
+	public @NotNull Component tooltip() {
 		return mapOption.tooltip();
 	}
 


### PR DESCRIPTION
- Bumped Java version to 25, as required by 26.1.
- Bumped dependencies to latest available for 26.1.
- Migrated mappings to Mojang Mappings, and converted buildscript to the new unobfuscated version of Loom.
- Fabric API was made `implementation` rather than `runtimeOnly` due to the latter causing a crash on startup, likely a mod shipping an old version of FAPI.